### PR TITLE
Ptb v20.0a5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,6 @@
 
   *I'm making this note to whoever comes to see this repo. (I came through a lot to make this bot) - I would not say such dumb thing like this, the whole credits goes to [SaitamaRobot](https://github.com/AnimeKaizoku/SaitamaRobot). You might ask me what you did?, well i did some edits with my knowledge to make this bot like my own. I don't give a shit about any illegal problems if anyone comes with that GPLv3 license stuff. After all i came through a lot from many developers, No one ever told me/us anything not even a simple guide. So i will make this repo public so anyone can learn or get code from here for my future updates.*
 
-## Contributing
-[Contributing.md](https://github.com/Black-Bulls-Bots/zerotwobot/blob/main/CONTRIBUTING.md)
-
-## Code Of Conduct
-[Code_Of_Conduct.md](https://github.com/Black-Bulls-Bots/zerotwobot/blob/main/CODE_OF_CONDUCT.md)
-
-## Security Policy
-[Security_Policy.md](https://github.com/Black-Bulls-Bots/zerotwobot/blob/main/SECURITY.md)
-
 ## Bot stuff
 
 * Bot link : [Zero Two](https://t.me/joker_zero_two_bot)
@@ -36,6 +27,12 @@
 * Bot News/Updates : [News](https://t.me/blackbull_bots)
 * Me(Repo Owner) : [Joker Hacker](https://t.me/kishoreee)
 * Wiki : [Checkout Our Wiki](https://github.com/Black-Bulls-Bots/zerotwobot/wiki)
+  
+## Useful Links
+[Contributing](https://github.com/Black-Bulls-Bots/zerotwobot/blob/main/CONTRIBUTING.md)
+[Code of Conduct](https://github.com/Black-Bulls-Bots/zerotwobot/blob/main/CODE_OF_CONDUCT.md)
+[Security Policy](https://github.com/Black-Bulls-Bots/zerotwobot/blob/main/SECURITY.md)
+
 
 ## CREDITS
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ h2==3.2.0
 hpack==3.0.0
 hstspreload==2021.11.1
 httpcore==0.15.0
-httpx==0.23.0
+httpx==0.23.1
 humanize==3.12.0
 hyperframe==5.2.0
 idna==2.10
@@ -64,11 +64,12 @@ pyrate-limiter==2.4.7
 Pyrogram==1.2.9
 PySocks==1.7.1
 python-dotenv==0.19.2
-python-telegram-bot==20.0a4
+python-telegram-bot==20.0a6
 python-whatanime==0.1.2
 pytz==2021.3
 pytz-deprecation-shim==0.1.0.post0
 regex==2021.11.10
+requests==2.28.1
 rfc==0.1.0
 rfc3986==1.5.0
 rsa==4.7.2
@@ -82,7 +83,7 @@ speedtest-cli==2.1.3
 spongemock==0.3.4
 SQLAlchemy==1.4.32
 telegraph==2.1.0
-Telethon==1.24.0
+Telethon==1.26.0
 TgCrypto==1.2.2
 tornado==6.2
 tqdm==4.62.3

--- a/zerotwobot/__init__.py
+++ b/zerotwobot/__init__.py
@@ -46,7 +46,7 @@ if sys.version_info[0] < 3 or sys.version_info[1] < 9:
     quit(1)
 
 ENV = bool(os.environ.get("ENV", False))
-BOT_VERSION = "2.1"
+BOT_VERSION = "2.2"
 PTB_VERSION = ptb_version
 BOT_API_VERSION = __bot_api_version__
 PYTHON_VERSION = platform.python_version()

--- a/zerotwobot/modules/admin.py
+++ b/zerotwobot/modules/admin.py
@@ -1,11 +1,10 @@
 import html
 
-from telegram import ChatMemberAdministrator, Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.constants import ParseMode, ChatMemberStatus
+from telegram import ChatMemberAdministrator, Update, InlineKeyboardButton, InlineKeyboardMarkup, ChatMemberOwner
+from telegram.constants import ParseMode, ChatMemberStatus, ChatID, ChatType
 from telegram.error import BadRequest
 from telegram.ext import ContextTypes, CommandHandler, filters, CallbackQueryHandler
 from telegram.helpers import mention_html
-from telegram import constants
 
 from zerotwobot import DRAGONS, application
 from zerotwobot.modules.disable import DisableAbleCommandHandler
@@ -44,7 +43,7 @@ async def promote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
     promoter = await chat.get_member(user.id)
 
 
-    if message.from_user.id == constants.ChatID.ANONYMOUS_ADMIN:
+    if message.from_user.id == ChatID.ANONYMOUS_ADMIN:
         
         await message.reply_text(
             text="You are an anonymous admin.",
@@ -122,6 +121,7 @@ async def promote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
         chat.id,
         f"Successfully promoted <b>{user_member.user.first_name or user_id}</b>!",
         parse_mode=ParseMode.HTML,
+        message_thread_id=message.message_thread_id if chat.is_forum else None
     )
 
     log_message = (
@@ -151,7 +151,7 @@ async def demote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
     user_id = await extract_user(message, context, args)
     demoter = await chat.get_member(user.id)
 
-    if message.from_user.id == constants.ChatID.ANONYMOUS_ADMIN:
+    if message.from_user.id == ChatID.ANONYMOUS_ADMIN:
     
         await message.reply_text(
             text="You are an anonymous admin.",
@@ -203,7 +203,7 @@ async def demote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
         return
 
     try:
-        await bot.promoteChatMember(
+        await bot.promote_chat_member(
             chat.id,
             user_id,
             can_change_info=False,
@@ -223,6 +223,7 @@ async def demote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
             chat.id,
             f"Sucessfully demoted <b>{user_member.user.first_name or user_id}</b>!",
             parse_mode=ParseMode.HTML,
+            message_thread_id=message.message_thread_id if chat.is_forum else None
         )
 
         log_message = (
@@ -238,7 +239,7 @@ async def demote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
             "Could not demote. I might not be admin, or the admin status was appointed by another"
             " user, so I can't act upon them!",
         )
-        return
+        raise
 
 
 
@@ -326,13 +327,14 @@ async def set_title(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await bot.setChatAdministratorCustomTitle(chat.id, user_id, title)
     except BadRequest:
         await message.reply_text("Either they aren't promoted by me or you set a title text that is impossible to set.")
-        return
+        raise
 
     await bot.sendMessage(
         chat.id,
         f"Successfully set title for <code>{user_member.user.first_name or user_id}</code> "
         f"to <code>{html.escape(title[:16])}</code>!",
         parse_mode=ParseMode.HTML,
+        message_thread_id=message.message_thread_id if chat.is_forum else None
     )
 
 
@@ -514,7 +516,7 @@ async def invite(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if chat.username:
         await update.effective_message.reply_text(f"https://t.me/{chat.username}")
-    elif chat.type in [chat.SUPERGROUP, chat.CHANNEL]:
+    elif chat.type in [ChatType.SUPERGROUP, ChatType.CHANNEL]:
         bot_member = await chat.get_member(bot.id)
         if (bot_member.can_invite_users if isinstance(bot_member, ChatMemberAdministrator) else None):
             invitelink = await bot.exportChatInviteLink(chat.id)
@@ -553,61 +555,43 @@ async def adminlist(update: Update, context: ContextTypes.DEFAULT_TYPE):
     administrators = await bot.getChatAdministrators(chat_id)
     text = "Admins in <b>{}</b>:".format(html.escape(update.effective_chat.title))
 
-    for admin in administrators:
-        user = admin.user
-        status = admin.status
-        custom_title = admin.custom_title
-
-        if user.first_name == "":
-            name = "☠ Deleted Account"
-        else:
-            name = "{}".format(
-                mention_html(
-                    user.id, html.escape(user.first_name + " " + (user.last_name or "")),
-                ),
-            )
-
-        if user.is_bot:
-            administrators.remove(admin)
-            continue
-
-        # if user.username:
-        #    name = escape_markdown("@" + user.username)
-        if status == ChatMemberStatus.OWNER:
-            text += "\n 👑 Creator:"
-            text += "\n<code> • </code>{}\n".format(name)
-
-            if custom_title:
-                text += f"<code> ┗━ {html.escape(custom_title)}</code>\n"
-
-    text += "\n🔱 Admins:"
-
     custom_admin_list = {}
     normal_admin_list = []
 
     for admin in administrators:
-        user = admin.user
-        status = admin.status
-        custom_title = admin.custom_title
+        if isinstance(admin, (ChatMemberAdministrator, ChatMemberOwner)):
+            user = admin.user
+            status = admin.status
+            custom_title = admin.custom_title
 
-        if user.first_name == "":
-            name = "☠ Deleted Account"
-        else:
-            name = "{}".format(
-                mention_html(
-                    user.id, html.escape(user.first_name + " " + (user.last_name or "")),
-                ),
-            )
-        # if user.username:
-        #    name = escape_markdown("@" + user.username)
-        if status == ChatMemberStatus.ADMINISTRATOR:
-            if custom_title:
-                try:
-                    custom_admin_list[custom_title].append(name)
-                except KeyError:
-                    custom_admin_list.update({custom_title: [name]})
+            if user.first_name == "":
+                name = "☠ Deleted Account"
             else:
-                normal_admin_list.append(name)
+                name = "{}".format(
+                    mention_html(
+                        user.id, html.escape(user.first_name + " " + (user.last_name or "")),
+                    ),
+                )
+
+            # if user.username:
+            #    name = escape_markdown("@" + user.username)
+            if status == ChatMemberStatus.OWNER:
+                text += "\n 👑 Creator:"
+                text += "\n<code> • </code>{}\n".format(name)
+
+                if custom_title:
+                    text += f"<code> ┗━ {html.escape(custom_title)}</code>\n"
+            
+            if status == ChatMemberStatus.ADMINISTRATOR:
+                if custom_title:
+                    try:
+                        custom_admin_list[custom_title].append(name)
+                    except KeyError:
+                        custom_admin_list.update({custom_title: [name]})
+                else:
+                    normal_admin_list.append(name)
+
+    text += "\n🔱 Admins:"
 
     for admin in normal_admin_list:
         text += "\n<code> • </code>{}".format(admin)

--- a/zerotwobot/modules/admin.py
+++ b/zerotwobot/modules/admin.py
@@ -487,7 +487,10 @@ async def unpinall(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
 
 
     try:
-        await bot.unpin_all_chat_messages(chat.id)
+        if chat.is_forum:
+            await bot.unpin_all_forum_topic_messages(chat.id, message.message_thread_id)
+        else:
+            await bot.unpin_all_chat_messages(chat.id)
     except BadRequest as excp:
         if excp.message == "Chat_not_modified":
             pass
@@ -945,7 +948,10 @@ async def admin_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         try:
-            await bot.unpin_all_chat_messages(chat.id)
+            if chat.is_forum:
+                await bot.unpin_all_forum_topic_messages(chat.id, message.message_thread_id)
+            else:
+                await bot.unpin_all_chat_messages(chat.id)
         except BadRequest as excp:
             if excp.message == "Chat_not_modified":
                 pass
@@ -968,7 +974,7 @@ __help__ = """
 *Admins only:*
  • `/pin`*:* silently pins the message replied to - add `'loud'` or `'notify'` to give notifs to users
  • `/unpin`*:* unpins the currently pinned message
- • `/unpinall`*:* unpins all the pinned message (only OWNER can do.)
+ • `/unpinall`*:* unpins all the pinned message, works in topics too (only OWNER can do.)
  • `/invitelink`*:* gets invitelink
  • `/promote`*:* promotes the user replied to
  • `/demote`*:* demotes the user replied to

--- a/zerotwobot/modules/admin.py
+++ b/zerotwobot/modules/admin.py
@@ -108,7 +108,8 @@ async def promote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
                 can_restrict_members=bot_member.can_restrict_members,
                 can_pin_messages=bot_member.can_pin_messages,
                 can_manage_chat=bot_member.can_manage_chat,
-                can_manage_video_chats=bot_member.can_manage_video_chats
+                can_manage_video_chats=bot_member.can_manage_video_chats,
+                can_manage_topics=bot_member.can_manage_topics
             )
         except BadRequest as err:
             if err.message == "User_not_mutual_contact":
@@ -215,6 +216,7 @@ async def demote(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
             can_promote_members=False,
             can_manage_chat=False,
             can_manage_video_chats=False,
+            can_manage_topics=False
         )
 
         await bot.sendMessage(

--- a/zerotwobot/modules/anime.py
+++ b/zerotwobot/modules/anime.py
@@ -168,7 +168,7 @@ async def extract_arg(message: Message):
     if len(split) > 1:
         return split[1]
     reply = message.reply_to_message
-    if reply is not None:
+    if reply is not None and not reply.forum_topic_created:
         return reply.text
     return None
 

--- a/zerotwobot/modules/backups.py
+++ b/zerotwobot/modules/backups.py
@@ -97,7 +97,10 @@ async def import_data(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         try:
             for mod in DATA_IMPORT:
-                await mod.__import_data__(str(chat.id), data)
+                try:
+                    await mod.__import_data__(str(chat.id), data, message)
+                except TypeError:
+                    pass
         except Exception:
             await msg.reply_text(
                 f"An error occurred while recovering your data. The process failed. If you experience a problem with this, please take it to @{SUPPORT_CHAT}",
@@ -351,6 +354,7 @@ async def export_data(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ),
         reply_to_message_id=msg.message_id,
         parse_mode=ParseMode.MARKDOWN,
+        message_thread_id=msg.message_thread_id if chat.is_forum else None
     )
     os.remove("zerotwobot{}.backup".format(chat_id))  # Cleaning file
 

--- a/zerotwobot/modules/backups.py
+++ b/zerotwobot/modules/backups.py
@@ -58,7 +58,7 @@ async def import_data(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         with BytesIO() as file:
-            await file_info.download_to_object(out=file)
+            await file_info.download_to_memory(out=file)
             file.seek(0)
             data = json.load(file)
 

--- a/zerotwobot/modules/backups.py
+++ b/zerotwobot/modules/backups.py
@@ -58,7 +58,7 @@ async def import_data(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         with BytesIO() as file:
-            await file_info.download(out=file)
+            await file_info.download_to_object(out=file)
             file.seek(0)
             data = json.load(file)
 

--- a/zerotwobot/modules/bans.py
+++ b/zerotwobot/modules/bans.py
@@ -178,11 +178,11 @@ async def ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
             await message.delete()
             return log
 
-        await bot.send_sticker(chat.id, BAN_STICKER)  # banhammer marie sticker
+        await bot.send_sticker(chat.id, BAN_STICKER, message_thread_id=message.message_thread_id if chat.is_forum else None)  # banhammer marie sticker
         
         if reason:
             reply += f"\n<code> </code><b>•  Reason:</b> \n{html.escape(reason)}"
-        await bot.sendMessage(chat.id, reply, parse_mode=ParseMode.HTML)
+        await bot.sendMessage(chat.id, reply, parse_mode=ParseMode.HTML, message_thread_id=message.message_thread_id if chat.is_forum else None)
         return log
 
     except BadRequest as excp:
@@ -264,12 +264,13 @@ async def temp_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
 
     try:
         await chat.ban_member(user_id, until_date=bantime)
-        await bot.send_sticker(chat.id, BAN_STICKER)  # banhammer marie sticker
+        await bot.send_sticker(chat.id, BAN_STICKER, message_thread_id=message.message_thread_id if chat.is_forum else None)  # banhammer marie sticker
         await bot.sendMessage(
             chat.id,
             f"Banned! User {mention_html(member.user.id, html.escape(member.user.first_name))} "
             f"will be banned for {time_val}.",
             parse_mode=ParseMode.HTML,
+            message_thread_id=message.message_thread_id if chat.is_forum else None
         )
         return log
 
@@ -330,11 +331,12 @@ async def kick(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
 
     res = chat.unban_member(user_id)  # unban on current user = kick
     if res:
-        await bot.send_sticker(chat.id, BAN_STICKER)  # banhammer marie sticker
+        await bot.send_sticker(chat.id, BAN_STICKER, message_thread_id=message.message_thread_id if chat.is_forum else None)  # banhammer marie sticker
         await bot.sendMessage(
             chat.id,
             f"Capitain I have kicked, {mention_html(member.user.id, html.escape(member.user.first_name))}.",
             parse_mode=ParseMode.HTML,
+            message_thread_id=message.message_thread_id if chat.is_forum else None
         )
         log = (
             f"<b>{html.escape(chat.title)}:</b>\n"
@@ -610,11 +612,11 @@ async def bans_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             else:
                 await chat.ban_member(user_id)
 
-            await bot.send_sticker(chat.id, BAN_STICKER)  # banhammer marie sticker
+            await bot.send_sticker(chat.id, BAN_STICKER, message_thread_id=message.message_thread_id if chat.is_forum else None)  # banhammer marie sticker
 
             if reason:
                 reply += f"\n<code> </code><b>•  Reason:</b> \n{html.escape(reason)}"
-            await bot.sendMessage(chat.id, reply, parse_mode=ParseMode.HTML)
+            await bot.sendMessage(chat.id, reply, parse_mode=ParseMode.HTML,message_thread_id=message.message_thread_id if chat.is_forum else None)
             await query.answer(f"Done Banned User.")
             return log
 

--- a/zerotwobot/modules/blacklist.py
+++ b/zerotwobot/modules/blacklist.py
@@ -384,6 +384,7 @@ async def del_blacklist(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     await bot.sendMessage(
                         chat.id,
                         f"Muted {user.first_name} for using Blacklisted word: {trigger}!",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
                 elif getmode == 4:
@@ -393,6 +394,7 @@ async def del_blacklist(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         await bot.sendMessage(
                             chat.id,
                             f"Kicked {user.first_name} for using Blacklisted word: {trigger}!",
+                            message_thread_id=message.message_thread_id if chat.is_forum else None
                         )
                     return
                 elif getmode == 5:
@@ -401,6 +403,7 @@ async def del_blacklist(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     await bot.sendMessage(
                         chat.id,
                         f"Banned {user.first_name} for using Blacklisted word: {trigger}",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
                 elif getmode == 6:
@@ -410,6 +413,7 @@ async def del_blacklist(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     await bot.sendMessage(
                         chat.id,
                         f"Banned {user.first_name} until '{value}' for using Blacklisted word: {trigger}!",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
                 elif getmode == 7:
@@ -424,6 +428,7 @@ async def del_blacklist(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     await bot.sendMessage(
                         chat.id,
                         f"Muted {user.first_name} until '{value}' for using Blacklisted word: {trigger}!",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
             except BadRequest as excp:
@@ -432,7 +437,7 @@ async def del_blacklist(update: Update, context: ContextTypes.DEFAULT_TYPE):
             break
 
 
-def __import_data__(chat_id, data):
+async def __import_data__(chat_id, data, message):
     # set chat blacklist
     blacklist = data.get("blacklist", {})
     for trigger in blacklist:

--- a/zerotwobot/modules/blacklist_stickers.py
+++ b/zerotwobot/modules/blacklist_stickers.py
@@ -62,7 +62,11 @@ async def blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 parse_mode=ParseMode.HTML,
             )
             return
-    await send_message(update.effective_message, text, parse_mode=ParseMode.HTML)
+    await send_message(
+        update.effective_message, 
+        text, 
+        parse_mode=ParseMode.HTML,
+        )
 
 
 
@@ -128,7 +132,10 @@ async def add_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
         added = 0
         trigger = msg.reply_to_message.sticker.set_name
         if trigger is None:
-            await send_message(update.effective_message, "Sticker is invalid!")
+            await send_message(
+                update.effective_message, 
+                "Sticker is invalid!",
+            )
             return
         try:
             get = await bot.getStickerSet(trigger)
@@ -202,7 +209,8 @@ async def unblackliststicker(update: Update, context: ContextTypes.DEFAULT_TYPE)
                 )
             else:
                 await send_message(
-                    update.effective_message, "This sticker is not on the blacklist...!",
+                    update.effective_message, 
+                    "This sticker is not on the blacklist...!",
                 )
 
         elif successful == len(to_unblacklist):
@@ -232,7 +240,10 @@ async def unblackliststicker(update: Update, context: ContextTypes.DEFAULT_TYPE)
     elif msg.reply_to_message:
         trigger = msg.reply_to_message.sticker.set_name
         if trigger is None:
-            await send_message(update.effective_message, "Sticker is invalid!")
+            await send_message(
+                update.effective_message, 
+                "Sticker is invalid!",
+            )
             return
         success = sql.rm_from_stickers(chat_id, trigger.lower())
 
@@ -273,7 +284,8 @@ async def blacklist_mode(update: Update, context: ContextTypes.DEFAULT_TYPE):
     else:
         if update.effective_message.chat.type == "private":
             await send_message(
-                update.effective_message, "You can do this command in groups, not PM",
+                update.effective_message, 
+                "You can do this command in groups, not PM",
             )
             return ""
         chat = update.effective_chat
@@ -303,7 +315,11 @@ async def blacklist_mode(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if len(args) == 1:
                 teks = """It looks like you are trying to set a temporary value to blacklist, but has not determined the time; use `/blstickermode tban <timevalue>`.
                                           Examples of time values: 4m = 4 minute, 3h = 3 hours, 6d = 6 days, 5w = 5 weeks."""
-                await send_message(update.effective_message, teks, parse_mode="markdown")
+                await send_message(
+                    update.effective_message, 
+                    teks, 
+                    parse_mode="markdown",
+                )
                 return
             settypeblacklist = "temporary banned for {}".format(args[1])
             sql.set_blacklist_strength(chat_id, 6, str(args[1]))
@@ -311,7 +327,11 @@ async def blacklist_mode(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if len(args) == 1:
                 teks = """It looks like you are trying to set a temporary value to blacklist, but has not determined the time; use `/blstickermode tmute <timevalue>`.
                                           Examples of time values: 4m = 4 minute, 3h = 3 hours, 6d = 6 days, 5w = 5 weeks."""
-                await send_message(update.effective_message, teks, parse_mode="markdown")
+                await send_message(
+                    update.effective_message, 
+                    teks, 
+                    parse_mode="markdown",
+                )
                 return
             settypeblacklist = "temporary muted for {}".format(args[1])
             sql.set_blacklist_strength(chat_id, 7, str(args[1]))
@@ -329,7 +349,11 @@ async def blacklist_mode(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text = "Blacklist sticker mode changed, users will be `{}`!".format(
                 settypeblacklist,
             )
-        await send_message(update.effective_message, text, parse_mode="markdown")
+        await send_message(
+            update.effective_message, 
+            text, 
+            parse_mode="markdown",
+        )
         return (
             "<b>{}:</b>\n"
             "<b>Admin:</b> {}\n"
@@ -365,7 +389,11 @@ async def blacklist_mode(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text = "Blacklist sticker mode is currently set to *{}*.".format(
                 settypeblacklist,
             )
-        await send_message(update.effective_message, text, parse_mode=ParseMode.MARKDOWN)
+        await send_message(
+            update.effective_message, 
+            text, 
+            parse_mode=ParseMode.MARKDOWN,
+        )
     return ""
 
 
@@ -416,6 +444,7 @@ async def del_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
                             mention_markdown(user.id, user.first_name), trigger,
                         ),
                         parse_mode="markdown",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
                 elif getmode == 4:
@@ -428,6 +457,7 @@ async def del_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
                                 mention_markdown(user.id, user.first_name), trigger,
                             ),
                             parse_mode="markdown",
+                            message_thread_id=message.message_thread_id if chat.is_forum else None
                         )
                     return
                 elif getmode == 5:
@@ -439,6 +469,7 @@ async def del_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
                             mention_markdown(user.id, user.first_name), trigger,
                         ),
                         parse_mode="markdown",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
                 elif getmode == 6:
@@ -451,6 +482,7 @@ async def del_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
                             mention_markdown(user.id, user.first_name), value, trigger,
                         ),
                         parse_mode="markdown",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
                 elif getmode == 7:
@@ -468,6 +500,7 @@ async def del_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
                             mention_markdown(user.id, user.first_name), value, trigger,
                         ),
                         parse_mode="markdown",
+                        message_thread_id=message.message_thread_id if chat.is_forum else None
                     )
                     return
             except BadRequest as excp:
@@ -476,7 +509,7 @@ async def del_blackliststicker(update: Update, context: ContextTypes.DEFAULT_TYP
                 break
 
 
-def __import_data__(chat_id, data):
+async def __import_data__(chat_id, data, message):
     # set chat blacklist
     blacklist = data.get("sticker_blacklist", {})
     for trigger in blacklist:

--- a/zerotwobot/modules/dbcleanup.py
+++ b/zerotwobot/modules/dbcleanup.py
@@ -33,7 +33,10 @@ async def get_invalid_chats(update: Update, context: ContextTypes.DEFAULT_TYPE, 
                 except:
                     pass
             else:
-                progress_message = await bot.sendMessage(chat_id, progress_bar)
+                progress_message = await bot.sendMessage(
+                    chat_id, progress_bar, 
+                    message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
+                )
             progress += 5
 
         cid = chat.chat_id
@@ -122,8 +125,12 @@ async def callback_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if query_type == "db_leave_chat":
         if query.from_user.id in admin_list:
             await bot.editMessageText("Leaving chats ...", chat_id, message.message_id)
-            chat_count = get_muted_chats(update, context, True)
-            await bot.sendMessage(chat_id, f"Left {chat_count} chats.")
+            chat_count = get_invalid_chats(update, context, True)
+            await bot.sendMessage(
+                chat_id, 
+                f"Left {chat_count} chats.",
+                message_thread_id=message.message_thread_id if update.effective_chat.is_forum else None
+            )
         else:
             await query.answer("You are not allowed to use this.")
     elif query_type == "db_cleanup":
@@ -134,7 +141,11 @@ async def callback_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
             reply = "Cleaned up {} chats and {} gbanned users from db.".format(
                 invalid_chat_count, invalid_gban_count,
             )
-            await bot.sendMessage(chat_id, reply)
+            await bot.sendMessage(
+                chat_id, 
+                reply,
+                message_thread_id=message.message_thread_id if update.effective_chat.is_forum else None
+            )
         else:
             await query.answer("You are not allowed to use this.")
 

--- a/zerotwobot/modules/error_handler.py
+++ b/zerotwobot/modules/error_handler.py
@@ -121,6 +121,7 @@ async def list_errors(update: Update, context: ContextTypes.DEFAULT_TYPE):
             open("errors_msg.txt", "rb"),
             caption=f"Too many errors have occured..",
             parse_mode="html",
+            message_thread_id=update.effective_message.message_thread_id if update.effective_chat.is_forum else None
         )
         return
     await update.effective_message.reply_text(msg, parse_mode="html")

--- a/zerotwobot/modules/eval.py
+++ b/zerotwobot/modules/eval.py
@@ -39,13 +39,18 @@ async def send(msg, bot, update):
     if len(str(msg)) > 2000:
         with io.BytesIO(str.encode(msg)) as out_file:
             out_file.name = "output.txt"
-            await bot.send_document(chat_id=update.effective_chat.id, document=out_file)
+            await bot.send_document(
+                chat_id=update.effective_chat.id, 
+                document=out_file, 
+                message_thread_id=update.effective_message.message_thread_id if update.effective_chat.is_forum else None
+            )
     else:
         LOGGER.info(f"OUT: '{msg}'")
         await bot.send_message(
             chat_id=update.effective_chat.id,
             text=f"`{msg}`",
             parse_mode=ParseMode.MARKDOWN,
+            message_thread_id=update.effective_message.message_thread_id if update.effective_chat.is_forum else None
         )
 
 

--- a/zerotwobot/modules/feds.py
+++ b/zerotwobot/modules/feds.py
@@ -1697,7 +1697,7 @@ async def fed_import_bans(update: Update, context: ContextTypes.DEFAULT_TYPE):
             multi_import_username = []
             multi_import_reason = []
             with BytesIO() as file:
-                file_info.download(out=file)
+                file_info.download_to_object(out=file)
                 file.seek(0)
                 reading = file.read().decode("UTF-8")
                 splitting = reading.split("\n")
@@ -1776,7 +1776,7 @@ async def fed_import_bans(update: Update, context: ContextTypes.DEFAULT_TYPE):
             multi_import_lastname = []
             multi_import_username = []
             multi_import_reason = []
-            file_info.download(
+            file_info.download_to_memory(
                 "fban_{}.csv".format(msg.reply_to_message.document.file_id),
             )
             with open(

--- a/zerotwobot/modules/feds.py
+++ b/zerotwobot/modules/feds.py
@@ -289,6 +289,7 @@ async def join_fed(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         chat.title, getfed["fname"],
                     ),
                     parse_mode="markdown",
+                    message_thread_id=message.message_thread_id if chat.is_forum else None
                 )
 
         await message.reply_text(
@@ -325,6 +326,7 @@ async def leave_fed(update: Update, context: ContextTypes.DEFAULT_TYPE):
                             chat.title, fed_info["fname"],
                         ),
                         parse_mode="markdown",
+                        message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
                     )
             await send_message(
                 update.effective_message,
@@ -710,6 +712,7 @@ async def fed_ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 reason,
             ),
             parse_mode="HTML",
+            message_thread_id=message.message_thread_id if chat.is_forum else None
         )
         # Send message to owner if fednotif is enabled
         if getfednotif:
@@ -748,6 +751,7 @@ async def fed_ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         reason,
                     ),
                     parse_mode="HTML",
+                    message_thread_id=message.message_thread_id if chat.is_forum else None
                 )
         for fedschat in fed_chats:
             try:
@@ -868,6 +872,7 @@ async def fed_ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
             reason,
         ),
         parse_mode="HTML",
+        message_thread_id=message.message_thread_id if chat.is_forum else None
     )
     # Send message to owner if fednotif is enabled
     if getfednotif:
@@ -906,6 +911,7 @@ async def fed_ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     reason,
                 ),
                 parse_mode="HTML",
+                message_thread_id=message.message_thread_id if chat.is_forum else None
             )
     chats_in_fed = 0
     for fedschat in fed_chats:
@@ -1070,6 +1076,7 @@ async def unfban(update: Update, context: ContextTypes.DEFAULT_TYPE):
             fban_user_id,
         ),
         parse_mode="HTML",
+        message_thread_id=message.message_thread_id if chat.is_forum else None
     )
     # Send message to owner if fednotif is enabled
     if getfednotif:
@@ -1104,6 +1111,7 @@ async def unfban(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     fban_user_id,
                 ),
                 parse_mode="HTML",
+                message_thread_id=message.message_thread_id if chat.is_forum else None
             )
     unfbanned_in_chats = 0
     for fedchats in chat_list:
@@ -1254,6 +1262,7 @@ async def set_frules(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         user.first_name, getfed["fname"],
                     ),
                     parse_mode="markdown",
+                    message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
                 )
         await update.effective_message.reply_text(f"Rules have been changed to :\n{rules}!")
     else:
@@ -1321,7 +1330,12 @@ async def fed_broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE):
         for chat in chat_list:
             title = "*New broadcast from Fed {}*\n".format(fedinfo["fname"])
             try:
-                await bot.sendMessage(chat, title + text, parse_mode="markdown")
+                await bot.sendMessage(
+                    chat, 
+                    title + text, 
+                    parse_mode="markdown",
+                    message_thread_id=msg.message_thread_id if chat.is_forum else None
+                )
             except TelegramError:
                 try:
                     await application.bot.getChat(chat)
@@ -1768,7 +1782,12 @@ async def fed_import_bans(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     )
                     if failed >= 1:
                         teks += " {} Failed to import.".format(failed)
-                    await bot.send_message(get_fedlog, teks, parse_mode="markdown")
+                    await bot.send_message(
+                        get_fedlog, 
+                        teks, 
+                        parse_mode="markdown",
+                        message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
+                    )
         elif fileformat == "csv":
             multi_fed_id = []
             multi_import_userid = []
@@ -1847,7 +1866,12 @@ async def fed_import_bans(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     )
                     if failed >= 1:
                         teks += " {} Failed to import.".format(failed)
-                    await bot.send_message(get_fedlog, teks, parse_mode="markdown")
+                    await bot.send_message(
+                        get_fedlog, 
+                        teks, 
+                        parse_mode="markdown",
+                        message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
+                    )
         else:
             await send_message(update.effective_message, "This file is not supported.")
             return
@@ -2119,6 +2143,7 @@ async def subs_feds(update: Update, context: ContextTypes.DEFAULT_TYPE):
                             fedinfo["fname"], getfed["fname"],
                         ),
                         parse_mode="markdown",
+                        message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
                     )
         else:
             await send_message(
@@ -2184,6 +2209,7 @@ async def unsubs_feds(update: Update, context: ContextTypes.DEFAULT_TYPE):
                             fedinfo["fname"], getfed["fname"],
                         ),
                         parse_mode="markdown",
+                        message_thread_id=update.effective_message.message_thread_id if chat.is_forum else None
                     )
         else:
             await send_message(

--- a/zerotwobot/modules/feds.py
+++ b/zerotwobot/modules/feds.py
@@ -1795,7 +1795,7 @@ async def fed_import_bans(update: Update, context: ContextTypes.DEFAULT_TYPE):
             multi_import_lastname = []
             multi_import_username = []
             multi_import_reason = []
-            file_info.download_to_memory(
+            file_info.download_to_drive(
                 "fban_{}.csv".format(msg.reply_to_message.document.file_id),
             )
             with open(

--- a/zerotwobot/modules/fun.py
+++ b/zerotwobot/modules/fun.py
@@ -15,8 +15,6 @@ from telegram.ext import ContextTypes
 
 async def runs(update: Update, context: ContextTypes.DEFAULT_TYPE):
     temp = random.choice(fun_strings.RUN_STRINGS)
-    if update.effective_user.id == 1170714920:
-        temp = "Run everyone, they just dropped a bomb 💣💣"
     await update.effective_message.reply_text(temp)
 
 
@@ -85,9 +83,6 @@ async def slap(update: Update, context: ContextTypes.DEFAULT_TYPE):
     item = random.choice(fun_strings.ITEMS)
     hit = random.choice(fun_strings.HIT)
     throw = random.choice(fun_strings.THROW)
-
-    if update.effective_user.id == 1096215023:
-        temp = "@NeoTheKitty scratches {user2}"
 
     reply = temp.format(user1=user1, user2=user2, item=item, hits=hit, throws=throw)
 

--- a/zerotwobot/modules/gtranslator.py
+++ b/zerotwobot/modules/gtranslator.py
@@ -15,7 +15,7 @@ async def totranslate(update: Update, context: ContextTypes.DEFAULT_TYPE):
             problem_lang_code.append(key)
 
     try:
-        if message.reply_to_message:
+        if message.reply_to_message and not message.reply_to_message.forum_topic_created:
             args = update.effective_message.text.split(None, 1)
             if message.reply_to_message.text:
                 text = message.reply_to_message.text

--- a/zerotwobot/modules/helper_funcs/alternate.py
+++ b/zerotwobot/modules/helper_funcs/alternate.py
@@ -1,11 +1,11 @@
 from telegram.error import BadRequest
 from functools import wraps
-from telegram import Update
+from telegram import Update, Message
 from telegram.ext import ContextTypes
 from telegram.constants import ChatAction
 
 
-async def send_message(message, text, *args, **kwargs):
+async def send_message(message: Message, text, *args, **kwargs):
     try:
         return await message.reply_text(text, *args, **kwargs)
     except BadRequest as err:

--- a/zerotwobot/modules/helper_funcs/chat_status.py
+++ b/zerotwobot/modules/helper_funcs/chat_status.py
@@ -45,7 +45,6 @@ async def is_user_admin(chat: Chat, user_id: int, member: ChatMember = None) -> 
         chat.type == "private"
         or user_id in DRAGONS
         or user_id in DEV_USERS
-        or chat.all_members_are_administrators
         or user_id in [777000, 1087968824]
     ):  # Count telegram and Group Anonymous as admin
         return True
@@ -68,7 +67,7 @@ async def is_user_admin(chat: Chat, user_id: int, member: ChatMember = None) -> 
 
 
 async def is_bot_admin(chat: Chat, bot_id: int, bot_member: ChatMember = None) -> bool:
-    if chat.type == "private" or chat.all_members_are_administrators:
+    if chat.type == "private":
         return True
 
     if not bot_member:
@@ -89,7 +88,6 @@ async def is_user_ban_protected(chat: Chat, user_id: int, member: ChatMember = N
         or user_id in DEV_USERS
         or user_id in WOLVES
         or user_id in TIGERS
-        or chat.all_members_are_administrators
         or user_id in [777000, 1087968824]
     ):  # Count telegram and Group Anonymous as admin
         return True

--- a/zerotwobot/modules/helper_funcs/extraction.py
+++ b/zerotwobot/modules/helper_funcs/extraction.py
@@ -9,7 +9,7 @@ from telegram.error import BadRequest
 
 async def id_from_reply(message: Message):
     prev_message = message.reply_to_message
-    if not prev_message:
+    if not prev_message or prev_message.forum_topic_created:
         return None, None
     user_id = prev_message.from_user.id
     #if user id is from channel bot, then fetch channel id from sender_chat 

--- a/zerotwobot/modules/helper_funcs/misc.py
+++ b/zerotwobot/modules/helper_funcs/misc.py
@@ -22,14 +22,14 @@ class EqInlineKeyboardButton(InlineKeyboardButton):
 
 
 def split_message(msg: str) -> List[str]:
-    if len(msg) < MessageLimit.TEXT_LENGTH:
+    if len(msg) < MessageLimit.MAX_TEXT_LENGTH:
         return [msg]
 
     lines = msg.splitlines(True)
     small_msg = ""
     result = []
     for line in lines:
-        if len(small_msg) + len(line) < MessageLimit.TEXT_LENGTH:
+        if len(small_msg) + len(line) < MessageLimit.MAX_TEXT_LENGTH:
             small_msg += line
         else:
             result.append(small_msg)

--- a/zerotwobot/modules/helper_funcs/msg_types.py
+++ b/zerotwobot/modules/helper_funcs/msg_types.py
@@ -40,7 +40,7 @@ def get_note_type(msg: Message):
         else:
             data_type = Types.TEXT
 
-    elif msg.reply_to_message:
+    elif msg.reply_to_message and not msg.reply_to_message.forum_topic_created:
         entities = msg.reply_to_message.parse_entities()
         msgtext = msg.reply_to_message.text or msg.reply_to_message.caption
         if len(args) >= 2 and msg.reply_to_message.text:  # not caption, text
@@ -89,7 +89,7 @@ def get_welcome_type(msg: Message):
     text = ""
 
     try:
-        if msg.reply_to_message:
+        if msg.reply_to_message and not msg.reply_to_message.forum_topic_created:
             if msg.reply_to_message.text:
                 args = msg.reply_to_message.text
             else:
@@ -101,45 +101,46 @@ def get_welcome_type(msg: Message):
     except AttributeError:
         args = False
 
-    if msg.reply_to_message and msg.reply_to_message.sticker:
-        content = msg.reply_to_message.sticker.file_id
-        text = None
-        data_type = Types.STICKER
+    if msg.reply_to_message and not msg.reply_to_message.forum_topic_created:
+        if msg.reply_to_message.sticker:
+            content = msg.reply_to_message.sticker.file_id
+            text = None
+            data_type = Types.STICKER
 
-    elif msg.reply_to_message and msg.reply_to_message.document:
-        content = msg.reply_to_message.document.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.DOCUMENT
+        elif msg.reply_to_message.document:
+            content = msg.reply_to_message.document.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.DOCUMENT
 
-    elif msg.reply_to_message and msg.reply_to_message.photo:
-        content = msg.reply_to_message.photo[-1].file_id  # last elem = best quality
-        text = msg.reply_to_message.caption
-        data_type = Types.PHOTO
+        elif msg.reply_to_message.photo:
+            content = msg.reply_to_message.photo[-1].file_id  # last elem = best quality
+            text = msg.reply_to_message.caption
+            data_type = Types.PHOTO
 
-    elif msg.reply_to_message and msg.reply_to_message.audio:
-        content = msg.reply_to_message.audio.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.AUDIO
+        elif msg.reply_to_message.audio:
+            content = msg.reply_to_message.audio.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.AUDIO
 
-    elif msg.reply_to_message and msg.reply_to_message.voice:
-        content = msg.reply_to_message.voice.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.VOICE
+        elif msg.reply_to_message.voice:
+            content = msg.reply_to_message.voice.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.VOICE
 
-    elif msg.reply_to_message and msg.reply_to_message.video:
-        content = msg.reply_to_message.video.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.VIDEO
+        elif msg.reply_to_message.video:
+            content = msg.reply_to_message.video.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.VIDEO
 
-    elif msg.reply_to_message and msg.reply_to_message.video_note:
-        content = msg.reply_to_message.video_note.file_id
-        text = None
-        data_type = Types.VIDEO_NOTE
+        elif msg.reply_to_message and msg.reply_to_message.video_note:
+            content = msg.reply_to_message.video_note.file_id
+            text = None
+            data_type = Types.VIDEO_NOTE
 
     buttons = []
     # determine what the contents of the filter are - text, image, sticker, etc
     if args:
-        if msg.reply_to_message:
+        if msg.reply_to_message and not msg.reply_to_message.forum_topic_created:
             argumen = (
                 msg.reply_to_message.caption if msg.reply_to_message.caption else ""
             )
@@ -170,51 +171,58 @@ def get_filter_type(msg: Message):
         content = None
         text = msg.text.split(None, 2)[2]
         data_type = Types.TEXT
-
-    elif (
-        msg.reply_to_message
-        and msg.reply_to_message.text
-        and len(msg.text.split()) >= 2
-    ):
+    elif msg.reply_to_message.forum_topic_created:
         content = None
-        text = msg.reply_to_message.text
+        text = msg.text.split(None, 2)[2]
         data_type = Types.TEXT
+    elif msg.reply_to_message and not msg.reply_to_message.forum_topic_created:    
+        if (
+            msg.reply_to_message.text
+            and len(msg.text.split()) >= 2
+        ):
+            content = None
+            text = msg.reply_to_message.text
+            data_type = Types.TEXT
 
-    elif msg.reply_to_message and msg.reply_to_message.sticker:
-        content = msg.reply_to_message.sticker.file_id
-        text = None
-        data_type = Types.STICKER
+        elif msg.reply_to_message.sticker:
+            content = msg.reply_to_message.sticker.file_id
+            text = None
+            data_type = Types.STICKER
 
-    elif msg.reply_to_message and msg.reply_to_message.document:
-        content = msg.reply_to_message.document.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.DOCUMENT
+        elif msg.reply_to_message.document:
+            content = msg.reply_to_message.document.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.DOCUMENT
 
-    elif msg.reply_to_message and msg.reply_to_message.photo:
-        content = msg.reply_to_message.photo[-1].file_id  # last elem = best quality
-        text = msg.reply_to_message.caption
-        data_type = Types.PHOTO
+        elif msg.reply_to_message.photo:
+            content = msg.reply_to_message.photo[-1].file_id  # last elem = best quality
+            text = msg.reply_to_message.caption
+            data_type = Types.PHOTO
 
-    elif msg.reply_to_message and msg.reply_to_message.audio:
-        content = msg.reply_to_message.audio.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.AUDIO
+        elif msg.reply_to_message.audio:
+            content = msg.reply_to_message.audio.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.AUDIO
 
-    elif msg.reply_to_message and msg.reply_to_message.voice:
-        content = msg.reply_to_message.voice.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.VOICE
+        elif msg.reply_to_message.voice:
+            content = msg.reply_to_message.voice.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.VOICE
 
-    elif msg.reply_to_message and msg.reply_to_message.video:
-        content = msg.reply_to_message.video.file_id
-        text = msg.reply_to_message.caption
-        data_type = Types.VIDEO
+        elif msg.reply_to_message.video:
+            content = msg.reply_to_message.video.file_id
+            text = msg.reply_to_message.caption
+            data_type = Types.VIDEO
 
-    elif msg.reply_to_message and msg.reply_to_message.video_note:
-        content = msg.reply_to_message.video_note.file_id
-        text = None
-        data_type = Types.VIDEO_NOTE
+        elif msg.reply_to_message.video_note:
+            content = msg.reply_to_message.video_note.file_id
+            text = None
+            data_type = Types.VIDEO_NOTE
 
+        else:
+            text = None
+            data_type = None
+            content = None
     else:
         text = None
         data_type = None

--- a/zerotwobot/modules/locks.py
+++ b/zerotwobot/modules/locks.py
@@ -241,7 +241,7 @@ async def lock(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
                 await context.bot.set_chat_permissions(
                     chat_id=chat_id,
                     permissions=get_permission_list(
-                        eval(str(current_permission)),
+                        current_permission.to_dict(),
                         LOCK_CHAT_RESTRICTION[ltype.lower()],
                     ),
                 )
@@ -373,7 +373,7 @@ async def unlock(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
                 await context.bot.set_chat_permissions(
                     chat_id=chat_id,
                     permissions=get_permission_list(
-                        eval(str(current_permission)),
+                        current_permission.to_dict(),
                         UNLOCK_CHAT_RESTRICTION[ltype.lower()],
                     ),
                 )
@@ -645,7 +645,7 @@ def get_permission_list(current, new):
     return new_permissions
 
 
-def __import_data__(chat_id, data):
+async def __import_data__(chat_id, data, message):
     # set chat locks
     locks = data.get("locks", {})
     for itemlock in locks:

--- a/zerotwobot/modules/locks.py
+++ b/zerotwobot/modules/locks.py
@@ -70,6 +70,8 @@ LOCK_CHAT_RESTRICTION = {
         "can_change_info": False,
         "can_invite_users": False,
         "can_pin_messages": False,
+        "can_manage_topics": False,
+
     },
     "messages": {"can_send_messages": False},
     "media": {"can_send_media_messages": False},
@@ -81,6 +83,8 @@ LOCK_CHAT_RESTRICTION = {
     "info": {"can_change_info": False},
     "invite": {"can_invite_users": False},
     "pin": {"can_pin_messages": False},
+    "topics": {"can_manage_topics": False},
+
 }
 
 UNLOCK_CHAT_RESTRICTION = {
@@ -91,6 +95,7 @@ UNLOCK_CHAT_RESTRICTION = {
         "can_send_other_messages": True,
         "can_add_web_page_previews": True,
         "can_invite_users": True,
+        "can_manage_topics": True,
     },
     "messages": {"can_send_messages": True},
     "media": {"can_send_media_messages": True},
@@ -102,6 +107,7 @@ UNLOCK_CHAT_RESTRICTION = {
     "info": {"can_change_info": True},
     "invite": {"can_invite_users": True},
     "pin": {"can_pin_messages": True},
+    "topics": {"can_manage_topics": True},
 }
 
 PERM_GROUP = 1
@@ -577,6 +583,8 @@ async def build_lock_message(chat_id):
         permslist.append("info = `{}`".format(permissions.can_change_info))
         permslist.append("invite = `{}`".format(permissions.can_invite_users))
         permslist.append("pin = `{}`".format(permissions.can_pin_messages))
+        permslist.append("topics = `{}`".format(permissions.can_manage_topics))
+
 
     if locklist:
         # Ordering lock list
@@ -629,6 +637,7 @@ def get_permission_list(current, new):
         "can_change_info": None,
         "can_invite_users": None,
         "can_pin_messages": None,
+        "can_manage_topics": None,
     }
     permissions.update(current)
     permissions.update(new)

--- a/zerotwobot/modules/muting.py
+++ b/zerotwobot/modules/muting.py
@@ -86,6 +86,7 @@ async def mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
             chat.id,
             f"Muted <b>{html.escape(member.user.first_name)}</b> with no expiration date!",
             parse_mode=ParseMode.HTML,
+            message_thread_id=message.message_thread_id if chat.is_forum else None
         )
         return log
 
@@ -137,6 +138,7 @@ async def unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
                 chat.id,
                 f"I shall allow <b>{html.escape(member.user.first_name)}</b> to text!",
                 parse_mode=ParseMode.HTML,
+                message_thread_id=message.message_thread_id if chat.is_forum else None
             )
             return (
                 f"<b>{html.escape(chat.title)}:</b>\n"
@@ -211,6 +213,7 @@ async def temp_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
                 chat.id,
                 f"Muted <b>{html.escape(member.user.first_name)}</b> for {time_val}!",
                 parse_mode=ParseMode.HTML,
+                message_thread_id=message.message_thread_id if chat.is_forum else None
             )
             return log
         else:

--- a/zerotwobot/modules/purge.py
+++ b/zerotwobot/modules/purge.py
@@ -46,7 +46,7 @@ async def purge_messages(event):
     try:
         await event.client.delete_messages(event.chat_id, messages)
     except:
-        pass
+        raise
     time_ = time.perf_counter() - start
     text = f"Purged Successfully in {time_:0.2f} Second(s)"
     await event.respond(text, parse_mode="markdown")

--- a/zerotwobot/modules/reporting.py
+++ b/zerotwobot/modules/reporting.py
@@ -71,7 +71,12 @@ async def report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
     chat = update.effective_chat
     user = update.effective_user
 
-    if chat and message.reply_to_message and sql.chat_should_report(chat.id):
+    if (
+        chat 
+        and message.reply_to_message 
+        and not message.reply_to_message.forum_topic_created 
+        and sql.chat_should_report(chat.id)
+        ):
         reported_user = message.reply_to_message.from_user
         chat_name = chat.title or chat.first or chat.username
         admin_list = await chat.get_administrators()

--- a/zerotwobot/modules/reverse.py
+++ b/zerotwobot/modules/reverse.py
@@ -51,7 +51,7 @@ async def reverse(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         photo = message.reply_to_message.photo[-1]
         file = await context.bot.get_file(photo.file_id)
-        await file.download("reverse.jpg")
+        await file.download_to_memory("reverse.jpg")
 
         await edit.edit_text("Downloaded Image, uploading to google...")
 

--- a/zerotwobot/modules/reverse.py
+++ b/zerotwobot/modules/reverse.py
@@ -47,7 +47,7 @@ async def reverse(update: Update, context: ContextTypes.DEFAULT_TYPE):
         try:
             edit = await message.reply_text("Downloading Image")
         except BadRequest:
-            edit = await context.bot.send_message(update.effective_chat.id, "Downloading Image")
+            return
 
         photo = message.reply_to_message.photo[-1]
         file = await context.bot.get_file(photo.file_id)

--- a/zerotwobot/modules/reverse.py
+++ b/zerotwobot/modules/reverse.py
@@ -51,7 +51,7 @@ async def reverse(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         photo = message.reply_to_message.photo[-1]
         file = await context.bot.get_file(photo.file_id)
-        await file.download_to_memory("reverse.jpg")
+        await file.download_to_drive("reverse.jpg")
 
         await edit.edit_text("Downloaded Image, uploading to google...")
 

--- a/zerotwobot/modules/rules.py
+++ b/zerotwobot/modules/rules.py
@@ -35,6 +35,7 @@ async def send_rules(update, chat_id, from_pm=False):
                 user.id,
                 "The rules shortcut for this chat hasn't been set properly! Ask admins to "
                 "fix this.\nMaybe they forgot the hyphen in ID",
+                message_thread_id= update.effective_message.message_thread_id if chat.is_forum else None,
             )
             return
         else:
@@ -53,7 +54,7 @@ async def send_rules(update, chat_id, from_pm=False):
             "The group admins haven't set any rules for this chat yet. "
             "This probably doesn't mean it's lawless though...!",
         )
-    elif rules and reply_msg:
+    elif rules and reply_msg and not reply_msg.forum_topic_created:
         await reply_msg.reply_text(
             "Please click the button below to see the rules.",
             reply_markup=InlineKeyboardMarkup(
@@ -114,7 +115,7 @@ def __stats__():
     return f"• {sql.num_chats()} chats have rules set."
 
 
-def __import_data__(chat_id, data):
+async def __import_data__(chat_id, data, message):
     # set chat rules
     rules = data.get("info", {}).get("rules", "")
     sql.set_rules(chat_id, rules)

--- a/zerotwobot/modules/shell.py
+++ b/zerotwobot/modules/shell.py
@@ -10,6 +10,7 @@ from telegram.ext import ContextTypes, CommandHandler
 @dev_plus
 async def shell(update: Update, context: ContextTypes.DEFAULT_TYPE):
     message = update.effective_message
+    chat = update.effective_chat
     cmd = message.text.split(" ", 1)
     if len(cmd) == 1:
         await message.reply_text("No command to execute was given.")
@@ -37,6 +38,7 @@ async def shell(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 filename=doc.name,
                 reply_to_message_id=message.message_id,
                 chat_id=message.chat_id,
+                message_thread_id=message.message_thread_id if chat.is_forum else None
             )
     else:
         await message.reply_text(reply, parse_mode=ParseMode.MARKDOWN)

--- a/zerotwobot/modules/sql/locks_sql.py
+++ b/zerotwobot/modules/sql/locks_sql.py
@@ -287,7 +287,7 @@ def is_locked(chat_id, lock_type):
         return curr_perm.emojicustom
     elif lock_type == "stickerpremium":
         return curr_perm.stickerpremium
-    elif lock_type == "stickeranimated0":
+    elif lock_type == "stickeranimated":
         return curr_perm.stickeranimated
 
 

--- a/zerotwobot/modules/sql/locks_sql.py
+++ b/zerotwobot/modules/sql/locks_sql.py
@@ -80,6 +80,9 @@ class Restrictions(BASE):
     media = Column(Boolean, default=False)
     other = Column(Boolean, default=False)
     preview = Column(Boolean, default=False)
+    info = Column(Boolean, default=False)
+    invite = Column(Boolean, default=False)
+    topics = Column(Boolean, default=False)
 
     def __init__(self, chat_id):
         self.chat_id = str(chat_id)  # ensure string
@@ -87,6 +90,9 @@ class Restrictions(BASE):
         self.media = False
         self.other = False
         self.preview = False
+        self.info = False
+        self.invite = False
+        self.topics = False
 
     def __repr__(self):
         return "<Restrictions for %s>" % self.chat_id
@@ -204,11 +210,20 @@ def update_restriction(chat_id, restr_type, locked):
             curr_restr.other = locked
         elif restr_type == "previews":
             curr_restr.preview = locked
+        elif restr_type == "info":
+            curr_restr.info = locked
+        elif restr_type == "invite":
+            curr_restr.invite = locked
+        elif restr_type == "topics":
+            curr_restr.topics = locked
         elif restr_type == "all":
             curr_restr.messages = locked
             curr_restr.media = locked
             curr_restr.other = locked
             curr_restr.preview = locked
+            curr_restr.info = locked
+            curr_restr.invite = locked
+            curr_restr.topcis = locked
         SESSION.add(curr_restr)
         SESSION.commit()
 
@@ -291,12 +306,21 @@ def is_restr_locked(chat_id, lock_type):
         return curr_restr.other
     elif lock_type == "previews":
         return curr_restr.preview
+    elif lock_type == "info":
+        return curr_restr.info
+    elif lock_type == "invite":
+        return curr_restr.invite
+    elif lock_type == "topics":
+        return curr_restr.topics
     elif lock_type == "all":
         return (
             curr_restr.messages
             and curr_restr.media
             and curr_restr.other
             and curr_restr.preview
+            and curr_restr.info
+            and curr_restr.invite
+            and curr_restr.topics
         )
 
 

--- a/zerotwobot/modules/sql/topics_sql.py
+++ b/zerotwobot/modules/sql/topics_sql.py
@@ -1,0 +1,54 @@
+import threading
+
+from zerotwobot.modules.sql import BASE, SESSION
+from sqlalchemy import Column, String, distinct, func
+
+
+class TopicsAction(BASE):
+    __tablename__ = "topic_actions"
+    chat_id = Column(String(14), primary_key=True)
+    action_topic = Column(String(14))
+
+    def __init__(self, chat_id):
+        self.chat_id = chat_id
+
+    def __repr__(self):
+        return "<Chat {} action_topic: {}>".format(self.chat_id, self.action_topic)
+
+
+TopicsAction.__table__.create(checkfirst=True)
+
+INSERTION_LOCK = threading.RLock()
+
+
+def set_action_topic(chat_id: int, action_chat: int) -> int:
+    with INSERTION_LOCK:
+        action_topic = SESSION.query(TopicsAction).get(str(chat_id))
+        if not action_topic:
+            action_topic = TopicsAction(str(chat_id))
+        action_topic.action_topic = action_chat
+
+        SESSION.add(action_topic)
+        SESSION.commit()
+
+
+def get_action_topic(chat_id: int) -> int:
+    action_topic = SESSION.query(TopicsAction).get(str(chat_id))
+    ret = None
+    if action_topic:
+        ret = action_topic.action_topic
+
+    SESSION.close()
+    return ret
+
+
+def del_action_topic(chat_id: int) -> bool:
+    with INSERTION_LOCK:
+        action_topic = SESSION.query(TopicsAction).get(str(chat_id))
+        if action_topic:
+            SESSION.delete(action_topic)
+            SESSION.commit()
+            return True
+        else:
+            SESSION.close()
+            return False

--- a/zerotwobot/modules/sql/topics_sql.py
+++ b/zerotwobot/modules/sql/topics_sql.py
@@ -32,7 +32,7 @@ def set_action_topic(chat_id: int, action_chat: int) -> int:
         SESSION.commit()
 
 
-def get_action_topic(chat_id: int) -> int:
+def get_action_topic(chat_id: int) -> int | None:
     action_topic = SESSION.query(TopicsAction).get(str(chat_id))
     ret = None
     if action_topic:

--- a/zerotwobot/modules/stickers.py
+++ b/zerotwobot/modules/stickers.py
@@ -69,7 +69,7 @@ async def getsticker(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if msg.reply_to_message and msg.reply_to_message.sticker:
         file_id = msg.reply_to_message.sticker.file_id
         new_file = await bot.get_file(file_id)
-        await new_file.download_to_memory(f"sticker_{user.id}.png")
+        await new_file.download_to_drive(f"sticker_{user.id}.png")
         await bot.send_document(
             chat.id, 
             document=open(f"sticker_{user.id}.png", "rb"),
@@ -135,13 +135,13 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         kang_file = await context.bot.get_file(file_id)
         if not is_animated and not (is_video or is_gif):
-            await kang_file.download_to_memory(f"kangsticker_{user.id}.png")
+            await kang_file.download_to_drive(f"kangsticker_{user.id}.png")
         elif is_animated:
-            await kang_file.download_to_memory(f"kangsticker_{user.id}.tgs")
+            await kang_file.download_to_drive(f"kangsticker_{user.id}.tgs")
         elif is_video and not is_gif:
-            await kang_file.download_to_memory(f"kangsticker_{user.id}.webm")
+            await kang_file.download_to_drive(f"kangsticker_{user.id}.webm")
         elif is_gif:
-            await kang_file.download_to_memory(f"kang_{user.id}.mp4")
+            await kang_file.download_to_drive(f"kang_{user.id}.mp4")
             convert_gif(f"kang_{user.id}.mp4")
 
         if args:

--- a/zerotwobot/modules/stickers.py
+++ b/zerotwobot/modules/stickers.py
@@ -65,12 +65,13 @@ async def getsticker(update: Update, context: ContextTypes.DEFAULT_TYPE):
     bot = context.bot
     msg = update.effective_message
     chat_id = update.effective_chat.id
+    user = update.effective_user
     if msg.reply_to_message and msg.reply_to_message.sticker:
         file_id = msg.reply_to_message.sticker.file_id
         new_file = await bot.get_file(file_id)
-        await new_file.download("sticker.png")
-        await bot.send_document(chat_id, document=open("sticker.png", "rb"))
-        os.remove("sticker.png")
+        await new_file.download_to_memory(f"sticker_{user.id}.png")
+        await bot.send_document(chat_id, document=open(f"sticker_{user.id}.png", "rb"))
+        os.remove("sticker_{user.id}.png")
     else:
         await update.effective_message.reply_text(
             "Please reply to a sticker for me to upload its PNG.",
@@ -103,7 +104,7 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
         except TelegramError as e:
             if e.message == "Stickerset_invalid":
                 packname_found = 1
-    kangsticker = "kangsticker.png"
+    kangsticker = f"kangsticker_{user.id}.png"
     is_animated = False
     is_video = False
     is_gif = False
@@ -129,14 +130,14 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         kang_file = await context.bot.get_file(file_id)
         if not is_animated and not (is_video or is_gif):
-            await kang_file.download("kangsticker.png")
+            await kang_file.download_to_memory(f"kangsticker_{user.id}.png")
         elif is_animated:
-            await kang_file.download("kangsticker.tgs")
+            await kang_file.download_to_memory(f"kangsticker_{user.id}.tgs")
         elif is_video and not is_gif:
-            await kang_file.download("kangsticker.webm")
+            await kang_file.download_to_memory(f"kangsticker_{user.id}.webm")
         elif is_gif:
-            await kang_file.download("kang.mp4")
-            convert_gif("kang.mp4")
+            await kang_file.download_to_memory(f"kang_{user.id}.mp4")
+            convert_gif(f"kang_{user.id}.mp4")
 
         if args:
             sticker_emoji = str(args[0])
@@ -171,7 +172,7 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await context.bot.add_sticker_to_set(
                     user_id=user.id,
                     name=packname,
-                    png_sticker=open("kangsticker.png", "rb"),
+                    png_sticker=open(f"kangsticker_{user.id}.png", "rb"),
                     emojis=sticker_emoji,
                 )
                 await msg.reply_text(
@@ -195,14 +196,14 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         sticker_emoji,
                         packname,
                         packnum,
-                        png_sticker=open("kangsticker.png", "rb"),
+                        png_sticker=open(f"kangsticker_{user.id}.png", "rb"),
                     )
                 elif e.message == "Sticker_png_dimensions":
                     im.save(kangsticker, "PNG")
                     await context.bot.add_sticker_to_set(
                         user_id=user.id,
                         name=packname,
-                        png_sticker=open("kangsticker.png", "rb"),
+                        png_sticker=open(f"kangsticker_{user.id}.png", "rb"),
                         emojis=sticker_emoji,
                     )
                     await msg.reply_text(
@@ -250,7 +251,7 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await context.bot.add_sticker_to_set(
                     user_id=user.id,
                     name=packname,
-                    tgs_sticker=open("kangsticker.tgs", "rb"),
+                    tgs_sticker=open(f"kangsticker_{user.id}.tgs", "rb"),
                     emojis=sticker_emoji,
                 )
                 await msg.reply_text(
@@ -268,7 +269,7 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         sticker_emoji,
                         packname,
                         packnum,
-                        tgs_sticker=open("kangsticker.tgs", "rb"),
+                        tgs_sticker=open(f"kangsticker_{user.id}.tgs", "rb"),
                     )
                 elif e.message == "Invalid sticker emojis":
                     await msg.reply_text("Invalid emoji(s).")
@@ -330,7 +331,7 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         sticker_emoji,
                         packname,
                         packnum,
-                        webm_sticker=open("kangsticker.webm", "rb"),
+                        webm_sticker=open(f"kangsticker_{user.id}.webm", "rb"),
                     )
                 elif e.message == "Invalid sticker emojis":
                     await msg.reply_text("Invalid emoji(s)")
@@ -375,11 +376,11 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
             else:
                 im.thumbnail(maxsize)
             im.save(kangsticker, "PNG")
-            await msg.reply_photo(photo=open("kangsticker.png", "rb"))
+            await msg.reply_photo(photo=open(f"kangsticker_{user.id}.png", "rb"))
             await context.bot.add_sticker_to_set(
                 user_id=user.id,
                 name=packname,
-                png_sticker=open("kangsticker.png", "rb"),
+                png_sticker=open(f"kangsticker_{user.id}.png", "rb"),
                 emojis=sticker_emoji,
             )
             await msg.reply_text(
@@ -401,14 +402,14 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     sticker_emoji,
                     packname,
                     packnum,
-                    png_sticker=open("kangsticker.png", "rb"),
+                    png_sticker=open(f"kangsticker_{user.id}.png", "rb"),
                 )
             elif e.message == "Sticker_png_dimensions":
                 im.save(kangsticker, "PNG")
                 await context.bot.add_sticker_to_set(
                     user_id=user.id,
                     name=packname,
-                    png_sticker=open("kangsticker.png", "rb"),
+                    png_sticker=open(f"kangsticker_{user.id}.png", "rb"),
                     emojis=sticker_emoji,
                 )
                 await msg.reply_text(
@@ -446,14 +447,14 @@ async def kang(update: Update, context: ContextTypes.DEFAULT_TYPE):
             packs += f"[pack](t.me/addstickers/{packname})"
         await msg.reply_text(packs, parse_mode=ParseMode.MARKDOWN)
     try:
-        if os.path.isfile("kangsticker.png"):
-            os.remove("kangsticker.png")
-        elif os.path.isfile("kangsticker.tgs"):
-            os.remove("kangsticker.tgs")
-        elif os.path.isfile("kangsticker.webm"):
-            os.remove("kangsticker.webm")
-        elif os.path.isfile("kang.mp4"):
-            os.remove("kang.mp4")
+        if os.path.isfile(f"kangsticker_{user.id}.png"):
+            os.remove(f"kangsticker_{user.id}.png")
+        elif os.path.isfile(f"kangsticker_{user.id}.tgs"):
+            os.remove(f"kangsticker_{user.id}.tgs")
+        elif os.path.isfile(f"kangsticker_{user.id}.webm"):
+            os.remove(f"kangsticker_{user.id}.webm")
+        elif os.path.isfile(f"kang_{user.id}.mp4"):
+            os.remove(f"kang_{user.id}.mp4")
     except:
         pass
 

--- a/zerotwobot/modules/telegraph.py
+++ b/zerotwobot/modules/telegraph.py
@@ -52,7 +52,7 @@ async def telegraph(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     file = reply_msg.video.get_file()
                     file_name = reply_msg.video.file_name
 
-                downloaded_file = file.download_to_memory(TEMP_DOWNLOAD_LOC + "/" + file_name)
+                downloaded_file = file.download_to_drive(TEMP_DOWNLOAD_LOC + "/" + file_name)
                 await msg.edit_text("<code>Downloaded image/video</code>", parse_mode="html")
 
                 try:

--- a/zerotwobot/modules/telegraph.py
+++ b/zerotwobot/modules/telegraph.py
@@ -52,7 +52,7 @@ async def telegraph(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     file = reply_msg.video.get_file()
                     file_name = reply_msg.video.file_name
 
-                downloaded_file = file.download(TEMP_DOWNLOAD_LOC + "/" + file_name)
+                downloaded_file = file.download_to_memory(TEMP_DOWNLOAD_LOC + "/" + file_name)
                 await msg.edit_text("<code>Downloaded image/video</code>", parse_mode="html")
 
                 try:

--- a/zerotwobot/modules/telegraph.py
+++ b/zerotwobot/modules/telegraph.py
@@ -40,7 +40,7 @@ async def telegraph(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
     if len(args) >= 1:
-        if message.reply_to_message:
+        if message.reply_to_message and not message.reply_to_message.forum_topic_created:
             start = datetime.now()
             reply_msg = message.reply_to_message
 

--- a/zerotwobot/modules/topics.py
+++ b/zerotwobot/modules/topics.py
@@ -1,0 +1,275 @@
+import html
+
+from telegram import Update
+from telegram.error import BadRequest
+from telegram.ext import CommandHandler, ContextTypes, filters
+from telegram.helpers import mention_html
+from zerotwobot import application
+from zerotwobot.modules.helper_funcs.chat_status import check_admin, sudo_plus
+from zerotwobot.modules.log_channel import loggable
+from zerotwobot.modules.sql.topics_sql import (del_action_topic,
+                                               get_action_topic,
+                                               set_action_topic)
+
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def set_topic_action(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    
+    if chat.is_forum:
+        topic_id = message.message_thread_id
+        topic_chat = get_action_topic(chat.id)
+        if topic_chat:
+            await message.reply_text("Already a topic for actions enabled in this group, you can remove it and add new one.")
+            return ""
+        else:
+            set_action_topic(chat.id, topic_id)
+            await message.reply_text("I have successfully set this topic for actions.")
+            log_message = (
+                f"<b>{html.escape(chat.title)}:</b>\n"
+                f"#ACTIONTOPIC\n"
+                f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                f"<b>Topic ID:</b>{message.message_thread_id}"
+            )
+            return log_message
+    else:
+        await message.reply_text("Action Topic can be only enabled in Groups with Topic support.")
+        return ""
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def del_topic_action(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+
+    if chat.is_forum:
+        topic_chat = get_action_topic(chat.id)
+        if topic_chat:
+            res = del_action_topic(chat.id)
+            if res:
+                await message.reply_text(f"Successfully removed the old topic ({topic_chat}) chat for actions, You can set new one now.")
+                log_message = (
+                    f"<b>{html.escape(chat.title)}:</b>\n"
+                    f"#DELACTIONTOPIC\n"
+                    f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                    f"<b>Topic ID:</b>{topic_chat}"
+                )
+                return log_message
+            else:
+                await message.reply_text("I don't know this it didn't work, try again.")
+                return ""
+        else:
+            await message.reply_text("It seems like you haven't set any topic for actions, you can set one by using /setactiontopic in the topic.")
+            return ""
+    else:
+        await message.reply_text("Action Topic can be only removed in Groups with Topic support.")
+        return ""
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def create_topic(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    args = context.args
+    
+    if chat.is_forum:
+        if len(args) < 1:
+            await message.reply_text("You must give a name for the topic to create.")
+        else:
+            name = " ".join(args)
+            print(name)
+            try:
+                topic = await context.bot.create_forum_topic(chat.id, name)
+                await message.reply_text(f"Successfully created {topic.name}\nID: {topic.message_thread_id}" if topic else "Something happened")
+                await context.bot.sendMessage(
+                    chat_id=chat.id, 
+                    text=f"Congratulations {topic.name} created successfully\nID: {topic.message_thread_id}",
+                    message_thread_id=topic.message_thread_id
+                )
+                log_message = (
+                    f"<b>{html.escape(chat.title)}:</b>\n"
+                    f"#NEWTOPIC\n"
+                    f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                    f"<b>Topic Name:</b> {topic.name}\n"
+                    f"<b>Topic ID:</b> {topic.message_thread_id}"
+                )
+                return log_message
+            except BadRequest as e:
+                await message.reply_text(f"Something happened.\n{e.message}")
+                return ""
+    else:
+        await message.reply_text("Baka! You can create topics in topics enabled group only.") 
+        return ""
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def delete_topic(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    args = context.args
+    if chat.is_forum:
+        if len(args) > 0:
+            try:
+                topic_chat = await context.bot.delete_forum_topic(chat.id, args[0])
+                if topic_chat:
+                    await message.reply_text(f"Succesfully deleted {args[0]}")
+                    log_message = (
+                        f"<b>{html.escape(chat.title)}:</b>\n"
+                        f"#DELTOPIC\n"
+                        f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                        f"<b>Topic ID:</b> {args[0]}"
+                    )
+                    return log_message
+            except BadRequest as e:
+                await message.reply_text(f"Something happened.\n{e.message}")
+                raise
+        else:
+            await message.reply_text("You have to give topic ID to delete.")
+            return ""
+    else:
+        await message.reply_text("You can perform this in topics enabled groups only.")
+        return ""
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def close_topic(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    args = context.args
+    if chat.is_forum:
+        if len(args) > 0:
+            try:
+                topic_chat = await context.bot.close_forum_topic(chat.id, args[0])
+                if topic_chat:
+                    await message.reply_text(f"Succesfully Closed {args[0]}")
+                    log_message = (
+                        f"<b>{html.escape(chat.title)}:</b>\n"
+                        f"#CLOSETOPIC\n"
+                        f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                        f"<b>Topic ID:</b> {args[0]}"
+                    )
+                    return log_message
+            except BadRequest as e:
+                await message.reply_text(f"Something happened.\n{e.message}")
+                raise
+        else:
+            await message.reply_text("You have to give topic ID to close.")
+            return ""
+    else:
+        await message.reply_text("You can perform this in topics enabled groups only.")
+        return ""
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def open_topic(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    args = context.args
+    if chat.is_forum:
+        if len(args) > 0:
+            try:
+                topic_chat = await context.bot.reopen_forum_topic(chat.id, args[0])
+                if topic_chat:
+                    await message.reply_text(f"Succesfully Opened {args[0]}")
+                    log_message = (
+                        f"<b>{html.escape(chat.title)}:</b>\n"
+                        f"#OPENTOPIC\n"
+                        f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                        f"<b>Topic ID:</b> {args[0]}"
+                    )
+                    return log_message
+            except BadRequest as e:
+                await message.reply_text(f"Something happened.\n{e.message}")
+                raise
+        else:
+            await message.reply_text("You have to give topic ID to open.")
+            return ""
+    else:
+        await message.reply_text("You can perform this in topics enabled groups only.")
+        return ""
+
+@loggable
+@check_admin(permission="can_manage_topics", is_both=True)
+async def unpin_topic(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    args = context.args
+    if chat.is_forum:
+        if len(args) > 0:
+            try:
+                topic_chat = await context.bot.reopen_forum_topic(chat.id, args[0])
+                if topic_chat:
+                    await message.reply_text(f"Succesfully Opened {args[0]}")
+                    log_message = (
+                        f"<b>{html.escape(chat.title)}:</b>\n"
+                        f"#OPENTOPIC\n"
+                        f"<b>Admin:</b> {mention_html(user.id, user.first_name)}\n"
+                        f"<b>Topic ID:</b> {args[0]}"
+                    )
+                    return log_message
+            except BadRequest as e:
+                await message.reply_text(f"Something happened.\n{e.message}")
+                raise
+        else:
+            await message.reply_text("You have to give topic ID to open.")
+            return ""
+    else:
+        await message.reply_text("You can perform this in topics enabled groups only.")
+        return ""
+
+__mod_name__ = "Topics"
+
+__help__ = """
+Telegram introuduced new way of managing your chat called Forums(Topics)
+
+As a group management bot I have some useful commands to help you
+create, delete, close and reopen topics in your chat.
+
+• `/setactiontopic`*:* Set issuing topic for action messages such as welcome, goodbye, warns, bans,..etc
+• `/delactiontopic`*:* Delete default topic for actions messages.
+• `/topicnew`*:* Create new topic, requires topic name to create.
+• `/topicdel`*:* Delete an existing topic, requires topic ID to delete.  
+• `/topicclose`*:* Close an existing topic, requires topic ID to close.
+• `/topicopen`*:* Open an already closed topic, requires topic ID to open.  
+"""
+
+SET_TOPIC_HANDLER = CommandHandler("setactiontopic", set_topic_action, block=False)
+DEL_TOPIC_HANDLER = CommandHandler("delactiontopic", del_topic_action, block=False)
+CREATE_TOPIC_HANDLER = CommandHandler("topicnew", create_topic, block=False)
+DELETE_TOPIC_HANDLER = CommandHandler("topicdel", delete_topic, block=False)
+CLOSE_TOPIC_HANDLER = CommandHandler("topicclose", close_topic, block=False)
+OPEN_TOPIC_HANDLER = CommandHandler("topicopen", open_topic, block=False)
+
+application.add_handler(SET_TOPIC_HANDLER)
+application.add_handler(DEL_TOPIC_HANDLER)
+application.add_handler(CREATE_TOPIC_HANDLER)
+application.add_handler(DELETE_TOPIC_HANDLER)
+application.add_handler(CLOSE_TOPIC_HANDLER)
+application.add_handler(OPEN_TOPIC_HANDLER)
+
+
+__command_list__ = [
+    "setactiontopic",
+    "delactiontopic",
+    "topicnew",
+    "topicclose",
+    "topicopen",
+]
+
+__handlers__ = [
+    SET_TOPIC_HANDLER,
+    DEL_TOPIC_HANDLER,
+    CREATE_TOPIC_HANDLER,
+    DELETE_TOPIC_HANDLER,
+    CLOSE_TOPIC_HANDLER,
+    OPEN_TOPIC_HANDLER,
+]

--- a/zerotwobot/modules/userinfo.py
+++ b/zerotwobot/modules/userinfo.py
@@ -26,45 +26,45 @@ from zerotwobot.modules.users import get_user_id
 
 async def get_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
     bot, args = context.bot, context.args
-    message = update.effective_message
     chat = update.effective_chat
-    msg = update.effective_message
-    user_id = await extract_user(msg, context, args)
+    message = update.effective_message
+    user_id = await extract_user(message, context, args)
+    print(len(args))
 
-    if user_id:
-
-        if msg.reply_to_message and msg.reply_to_message.forward_from:
-
-            user1 = message.reply_to_message.from_user
-            user2 = message.reply_to_message.forward_from
-
-            await msg.reply_text(
-                f"<b>Telegram ID:</b>,"
-                f"• {html.escape(user2.first_name)} - <code>{user2.id}</code>.\n"
-                f"• {html.escape(user1.first_name)} - <code>{user1.id}</code>.",
+    if chat.is_forum:
+        if message.reply_to_message.forum_topic_created:
+            await message.reply_text(
+                f"This group's id is <code>:{chat.id}</code> \nThis topic's id is <code>{message.message_thread_id}</code>",
                 parse_mode=ParseMode.HTML,
             )
+            return
+            
+    if message.reply_to_message and message.reply_to_message.forward_from:
 
-        else:
+        user1 = message.reply_to_message.from_user
+        user2 = message.reply_to_message.forward_from
 
-            user = await bot.get_chat(user_id)
-            await msg.reply_text(
-                f"{html.escape(user.first_name)}'s id is <code>{user.id}</code>.",
-                parse_mode=ParseMode.HTML,
-            )
-
+        await message.reply_text(
+            f"<b>Telegram ID:</b>,\n"
+            f"• {html.escape(user2.first_name)} - <code>{user2.id}</code>.\n"
+            f"• {html.escape(user1.first_name)} - <code>{user1.id}</code>.",
+            parse_mode=ParseMode.HTML,
+        )
+    elif len(args) >= 1 or message.reply_to_message:
+        user = await bot.get_chat(user_id)
+        await message.reply_text(
+            f"{html.escape(user.first_name)}'s id is <code>{user.id}</code>.",
+            parse_mode=ParseMode.HTML,
+        )
+    elif chat.type == "private":
+        await message.reply_text(
+            f"Your id is <code>{chat.id}</code>.", parse_mode=ParseMode.HTML,
+        )
     else:
-
-        if chat.type == "private":
-            await msg.reply_text(
-                f"Your id is <code>{chat.id}</code>.", parse_mode=ParseMode.HTML,
-            )
-
-        else:
-            await msg.reply_text(
-                f"This group's id is <code>{chat.id}</code>.", parse_mode=ParseMode.HTML,
-            )
-
+        await message.reply_text(
+        f"This group's id is <code>{chat.id}</code>.", parse_mode=ParseMode.HTML,
+        )
+    return
 
 @ZerotwoTelethonClient.on(
     events.NewMessage(

--- a/zerotwobot/modules/userinfo.py
+++ b/zerotwobot/modules/userinfo.py
@@ -288,7 +288,7 @@ async def info(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if chat_obj.photo:
                 _file = await chat_obj.photo.get_big_file()
                 # _file = await bot.get_file(file_id)
-                await _file.download_to_memory(f"{chat_obj.id}.png")
+                await _file.download_to_drive(f"{chat_obj.id}.png")
 
                 await message.reply_photo(
                     photo=open(f"{chat_obj.id}.png", "rb"),

--- a/zerotwobot/modules/userinfo.py
+++ b/zerotwobot/modules/userinfo.py
@@ -110,7 +110,7 @@ async def group_info(event) -> None:
 
 async def gifid(update: Update, context: ContextTypes.DEFAULT_TYPE):
     msg = update.effective_message
-    if msg.reply_to_message and msg.reply_to_message.animation:
+    if msg.reply_to_message and msg.reply_to_message.animation and not msg.reply_to_message.forum_topic_created:
         await update.effective_message.reply_text(
             f"Gif ID:\n<code>{msg.reply_to_message.animation.file_id}</code>",
             parse_mode=ParseMode.HTML,
@@ -145,7 +145,7 @@ async def info(update: Update, context: ContextTypes.DEFAULT_TYPE):
             userid = user_id
     elif len(args) >= 1 and args[0].lstrip("-").isdigit():
         userid = int(args[0])
-    elif message.reply_to_message:
+    elif message.reply_to_message and not message.reply_to_message.forum_topic_created:
         if message.reply_to_message.sender_chat:
             userid = message.reply_to_message.sender_chat.id
         elif message.reply_to_message.from_user:
@@ -237,8 +237,6 @@ async def info(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 bot.username,
             )
 
-
-                
         for mod in USER_INFO:
             try:
                 mod_info = mod.__user_info__(chat_obj.id).strip()

--- a/zerotwobot/modules/userinfo.py
+++ b/zerotwobot/modules/userinfo.py
@@ -290,7 +290,7 @@ async def info(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if chat_obj.photo:
                 _file = await chat_obj.photo.get_big_file()
                 # _file = await bot.get_file(file_id)
-                await _file.download(f"{chat_obj.id}.png")
+                await _file.download_to_memory(f"{chat_obj.id}.png")
 
                 await message.reply_photo(
                     photo=open(f"{chat_obj.id}.png", "rb"),

--- a/zerotwobot/modules/users.py
+++ b/zerotwobot/modules/users.py
@@ -12,6 +12,7 @@ from telegram.ext import (
     MessageHandler,
 )
 from telegram.helpers import escape_markdown
+from zerotwobot.modules.sql.topics_sql import get_action_topic
 
 import zerotwobot.modules.sql.users_sql as sql
 from zerotwobot import DEV_USERS, LOGGER, OWNER_ID, application
@@ -76,11 +77,13 @@ async def broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if to_group:
             for chat in chats:
                 try:
+                    topic_chat = get_action_topic(chat.chat_id)
                     await context.bot.sendMessage(
                         int(chat.chat_id),
                         escape_markdown(to_send[1], 2),
                         parse_mode=ParseMode.MARKDOWN_V2,
                         disable_web_page_preview=True,
+                        message_thread_id=topic_chat if topic_chat else None
                     )
                     await asyncio.sleep(1)
                 except TelegramError as e:

--- a/zerotwobot/modules/warns.py
+++ b/zerotwobot/modules/warns.py
@@ -195,7 +195,7 @@ async def warn_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
     warner: Optional[User] = update.effective_user
 
     user_id, reason = await extract_user_and_text(message, context, args)
-    if message.text.startswith("/d") and message.reply_to_message:
+    if message.text.startswith("/d") and message.reply_to_message and not message.reply_to_message.forum_topic_created:
         await message.reply_to_message.delete()
     if user_id:
         if (
@@ -356,7 +356,7 @@ async def list_warn_filters(update: Update, context: ContextTypes.DEFAULT_TYPE):
     filter_list = CURRENT_WARNING_FILTER_STRING
     for keyword in all_handlers:
         entry = f" - {html.escape(keyword)}\n"
-        if len(entry) + len(filter_list) > MessageLimit.TEXT_LENGHT:
+        if len(entry) + len(filter_list) > MessageLimit.MAX_TEXT_LENGTH:
             await update.effective_message.reply_text(filter_list, parse_mode=ParseMode.HTML)
             filter_list = entry
         else:
@@ -478,7 +478,7 @@ def __stats__():
     )
 
 
-def __import_data__(chat_id, data):
+async def __import_data__(chat_id, data, message):
     for user_id, count in data.get("warns", {}).items():
         for x in range(int(count)):
             sql.warn_user(user_id, chat_id)

--- a/zerotwobot/modules/wiki.py
+++ b/zerotwobot/modules/wiki.py
@@ -9,7 +9,7 @@ from wikipedia.exceptions import DisambiguationError, PageError
 async def wiki(update: Update, context: ContextTypes.DEFAULT_TYPE):
     msg = (
         update.effective_message.reply_to_message
-        if update.effective_message.reply_to_message
+        if update.effective_message.reply_to_message and not update.effective_message.reply_to_message.forum_topic_created
         else update.effective_message
     )
     res = ""


### PR DESCRIPTION
## What's New
- Introducing action topic, a topic which you can set for actions like welcome, left messages since telegram didn't show any way for bots to message in a topic.
- New commands `/setactiontopic` and `/delactiontopic`.
- Admins can now create, close, delete, reopen topics using bot.

## What's Changed
- Update Bot Version
- Bump PTB to v20.0a6
- split downloading option into two
- add `can_manage_topic` to promote/demote and locktypes
- admins can lock topic permissions in groups
- /id command will show topic ID too which is useful in some places
- removed `all_members_are_administrators`
- added topics support across whole bot code
- removed unwanted things in fun module
- replace strings with enums
- bump requirements.txt